### PR TITLE
format peers as a colored list, show exit-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,17 @@ In your _config_ file add a new module as the example below.
 **Important!** Be sure to insert the correct path to the script in the _exec_ and _on-click_ fields.
 The script is executed every three seconds, but you can easily change it by modifying the _interval_ field.
 
+### Exit node
+
+`exit-node` can be included by changing the `format` key to:
+
+```json
+"format": "VPN: {icon} exit-node: {}",
+```
+
 ### Colored tooltip
 
-The status flag takes to optional parameters
+The status flag takes two optional parameters
 
 ```bash
 waybar-tailscale.sh --status "#a6e22e" "#f92672"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A super simple module to show and toggle the status of [Tailscale](https://tails
 ## Installation
 At first, you need to be able to use tailscale without using `sudo`. You can do that by executing:
 ```
-tailscale set --operator=$USER 
+tailscale set --operator=$USER
 ```
 After, you can simply clone the repository in your waybar's configuration folder, or where you prefer.
 ## Configuration
@@ -17,7 +17,7 @@ In your _config_ file add a new module as the example below.
     "exec-on-event": true,
     "format": "VPN: {icon}",
     "format-icons": {
-        "connected": "on",        
+        "connected": "on",
         "stopped": "off"
     },
     "tooltip": true,
@@ -27,6 +27,16 @@ In your _config_ file add a new module as the example below.
 ```
 **Important!** Be sure to insert the correct path to the script in the _exec_ and _on-click_ fields.
 The script is executed every three seconds, but you can easily change it by modifying the _interval_ field.
+
+### Colored tooltip
+
+The status flag takes to optional parameters
+
+```bash
+waybar-tailscale.sh --status "#a6e22e" "#f92672"
+```
+
+The first being the color of active nodes, the second the color of inactive nodes. defaults are respectively `green` and `red`.
 
 ## Contributing
 Even if this is a very trivial module, requests for new features and any issues you might find are welcomed.

--- a/waybar-tailscale.sh
+++ b/waybar-tailscale.sh
@@ -26,8 +26,9 @@ case $1 in
             T=${2:-"green"}
             F=${3:-"red"}
 
-            peers=$(tailscale status --json | jq -r --arg T "'$T'" --arg F "'$F'" '.Peer[] | ("<span color=" + (if .Online then $T else $F end) + ">" + (.DNSName | split(".")[0]) + "</span>")' | tr '\n' '\n')
-            echo "{\"text\":\"\",\"class\":\"connected\",\"alt\":\"connected\", \"tooltip\": \"\n$peers\"}"
+            peers=$(tailscale status --json | jq -r --arg T "'$T'" --arg F "'$F'" '.Peer[] | ("<span color=" + (if .Online then $T else $F end) + ">" + (.DNSName | split(".")[0]) + "</span>")' | tr '\n' '\r')
+            exitnode=$(tailscale status --json | jq -r '.Peer[] | select(.ExitNode == true).DNSName | split(".")[0]')
+            echo "{\"text\":\"${exitnode}\",\"class\":\"connected\",\"alt\":\"connected\", \"tooltip\": \"${peers}\"}"
         else
             echo "{\"text\":\"\",\"class\":\"stopped\",\"alt\":\"stopped\", \"tooltip\": \"The VPN is not active.\"}"
         fi

--- a/waybar-tailscale.sh
+++ b/waybar-tailscale.sh
@@ -23,8 +23,10 @@ toggle_status () {
 case $1 in
     --status)
         if tailscale_status; then
-            #TODO: find a way to format output
-            peers=$(echo "$(tailscale status)" | tr -d '\n')
+            T=${2:-"green"}
+            F=${3:-"red"}
+
+            peers=$(tailscale status --json | jq -r --arg T "'$T'" --arg F "'$F'" '.Peer[] | ("<span color=" + (if .Online then $T else $F end) + ">" + (.DNSName | split(".")[0]) + "</span>")' | tr '\n' '\n')
             echo "{\"text\":\"\",\"class\":\"connected\",\"alt\":\"connected\", \"tooltip\": \"\n$peers\"}"
         else
             echo "{\"text\":\"\",\"class\":\"stopped\",\"alt\":\"stopped\", \"tooltip\": \"The VPN is not active.\"}"


### PR DESCRIPTION
format peers in tooltip as a colored list.
option for showing the active exit node.

closes #1