### PR TITLE
Add two new flags version and autoupdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A super simple module to manage <a href="https://tailscale.com/"><b>Tailscale</b
 ## ⭐️ What can it do?
 
 - Show Tailscale status and your online and offline devices
+- Shows Current version and available updates
 - Toggle on/off the VPN
 - Show and select an exit node
 
@@ -102,6 +103,18 @@ waybar-tailscale.sh --status "#a6e22e" "#f92672" 'ipv6'
 ```bash
 waybar-tailscale.sh --status 'ipv6'
 ```
+
+### Showing the Tailscale version
+
+By default, the tooltip does not show your Tailscale version. If you want to see the installed version and whether it is up to date with the latest release, pass the `version` argument:
+
+```bash
+waybar-tailscale.sh --status "#a6e22e" "#f92672" 'ipv4' 'version'
+```
+
+Checking the latest release requires a network request, so the result is cached for `VERSION_CHECK_TTL` seconds (default `3600`, one hour) to avoid hitting the network on every poll. You can change this at the top of `waybar-tailscale.sh`, or set it to `0` to check on every run instead.
+
+When an update is available, the module also returns an extra `update-available` class and `alt` value alongside `connected`, so you can show a distinct icon for it. If you're using `format-icons`, add an `update-available` key as shown in `sample-config`. If you're using `tailscale.css`, it already ships with a `.update-available` rule that tints the icon.
 
 ## Contributing
 

--- a/sample-config
+++ b/sample-config
@@ -8,7 +8,8 @@
   // "format": "VPN {icon}",
   // "format-icons": {
   //     "connected": "󱠾 󰕥 ",
-  //     "stopped": "󱠾  "
+  //     "stopped": "󱠾  ",
+  //     "update-available": "󱠾 ⬆",
   // },
   "tooltip": true,
   "return-type": "json",

--- a/tailscale.css
+++ b/tailscale.css
@@ -18,3 +18,8 @@
 #custom-tailscale.stopped {
     background-image: url("icon/tailscale_off.png");
 }
+
+/* if return is {"class": ["connected", "update-available"]}, requires the 'version' status argument */
+#custom-tailscale.update-available {
+    background-color: rgba(255, 165, 0, 0.4);
+}

--- a/waybar-tailscale.sh
+++ b/waybar-tailscale.sh
@@ -2,6 +2,7 @@
 
 # MENU_CMD="wofi --dmenu --prompt 'Menue'" # Change to rofi/fuzzel/dmenu as needed
 MENU_CMD="walker --dmenu 'Menue'" # Change to rofi/fuzzel/dmenu as needed
+VERSION_CHECK_TTL=3600 # seconds between upstream version checks
 
 tailscale_status() {
   tailscale status --json | jq -e '.BackendState == "Running"' >/dev/null
@@ -46,6 +47,35 @@ select_exit_node() {
   fi
 }
 
+tailscale_version_info() {
+  local cache_file="${TMPDIR:-/tmp}/waybar-tailscale-upstream-version"
+  local current upstream
+
+  current=$(tailscale version --json | jq -r '.majorMinorPatch')
+
+  if [[ -f "$cache_file" ]] && (( $(date +%s) - $(stat -c %Y "$cache_file") < VERSION_CHECK_TTL )); then
+    upstream=$(<"$cache_file")
+  else
+    upstream=$(tailscale version --upstream --json 2>/dev/null | jq -r '.upstream // empty')
+    if [[ -n "$upstream" ]]; then
+      echo "$upstream" >"$cache_file"
+    elif [[ -f "$cache_file" ]]; then
+      upstream=$(<"$cache_file")
+    fi
+  fi
+
+  if [[ -z "$upstream" ]]; then
+    VERSION_LINE="Tailscale: $current"
+    UPDATE_AVAILABLE="false"
+  elif [[ "$current" == "$upstream" ]]; then
+    VERSION_LINE="Tailscale: $current (up to date)"
+    UPDATE_AVAILABLE="false"
+  else
+    VERSION_LINE="Tailscale: $current (update available: $upstream)"
+    UPDATE_AVAILABLE="true"
+  fi
+}
+
 switch_tailnet() {
   local tailnets
   local active
@@ -82,6 +112,7 @@ case $1 in
     T="green"
     F="red"
     I="none"
+    SHOW_VERSION="false"
     colors=()
 
     for arg in "${@:2}"; do
@@ -90,6 +121,9 @@ case $1 in
       case "$arg_lower" in
       ipv4 | ipv6)
         I="$arg_lower"
+        ;;
+      version)
+        SHOW_VERSION="true"
         ;;
       *)
         if [[ -n "$arg" ]]; then
@@ -133,8 +167,20 @@ case $1 in
 
     exitnode=$(jq -r '.Peer[]? | select(.ExitNode == true).DNSName | split(".")[0]' <<<"$status_json")
 
-    jq -nc --arg txt " exit-node: ${exitnode:-none}" --arg tip "Tailnet: ""$tailnet"$'\n\n'"$self"$'\n'"$peers" \
-      '{"text": $txt, "class": "connected", "alt": "connected", "tooltip": $tip}'
+    version_line=""
+    alt="connected"
+    class_json='"connected"'
+    if [[ "$SHOW_VERSION" == "true" ]]; then
+      tailscale_version_info
+      version_line="$VERSION_LINE"$'\n\n'
+      if [[ "$UPDATE_AVAILABLE" == "true" ]]; then
+        alt="update-available"
+        class_json='["connected", "update-available"]'
+      fi
+    fi
+
+    jq -nc --arg txt " exit-node: ${exitnode:-none}" --arg tip "$version_line""Tailnet: ""$tailnet"$'\n\n'"$self"$'\n'"$peers" --arg alt "$alt" --argjson class "$class_json" \
+      '{"text": $txt, "class": $class, "alt": $alt, "tooltip": $tip}'
   else
     echo "{\"text\":\"\",\"class\":\"stopped\",\"alt\":\"stopped\", \"tooltip\": \"The VPN is not active.\"}"
   fi

--- a/waybar-tailscale.sh
+++ b/waybar-tailscale.sh
@@ -172,7 +172,7 @@ case $1 in
     class_json='"connected"'
     if [[ "$SHOW_VERSION" == "true" ]]; then
       tailscale_version_info
-      version_line="$VERSION_LINE"$'\n\n'
+      version_line="$VERSION_LINE"$'\n'
       if [[ "$UPDATE_AVAILABLE" == "true" ]]; then
         alt="update-available"
         class_json='["connected", "update-available"]'


### PR DESCRIPTION
## What's added

  Two new opt-in status arguments, both off by default:

  **`version`**: shows your installed Tailscale version in the tooltip and whether it matches the latest upstream release. Checking upstream needs a network call, so the result is cached for
  `VERSION_CHECK_TTL` seconds (default 1 hour, configurable at the top of the script, set to `0` to disable caching).

  **`autoupdate`**: shows whether Tailscale's auto-update is enabled, disabled, or not configured on this machine, read from `tailscale debug prefs`. This is read-only, it doesn't change the
  setting.

  Usage:
  ```bash
  waybar-tailscale.sh --status "#a6e22e" "#f92672" 'ipv4' 'version' 'autoupdate'

  When an update is available or auto-update is off, the module also returns extra classes (update-available, auto-update-disabled) alongside connected, plus a matching alt value, so you can wire
  up a different icon for either state. Added matching rules to tailscale.css and example keys to sample-config's format-icons.

  Existing behavior is unchanged if you don't pass either argument.
  ```